### PR TITLE
fixup! Add optional defmt support

### DIFF
--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -150,3 +150,10 @@ impl fmt::Display for Utc {
         write!(f, "UTC")
     }
 }
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Utc {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "UTC");
+    }
+}


### PR DESCRIPTION
For the following struct, I get:

```rust
use serde::{Deserialize, Serialize};

#[derive(Debug, Clone, Serialize, Deserialize, Default)]
#[cfg_attr(feature = "defmt", derive(defmt::Format))]
pub struct Source<'a> {
    ///Distance of weather station to the requested `lat` and `lon` (if given), in meters
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub distance: Option<i64>,
    ///DWD weather station ID
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub dwd_station_id: Option<&'a str>,
    ///Timestamp of first available record for this source
    pub first_record: chrono::DateTime<chrono::Utc>,
    // [...]
}
```
```
error[E0277]: the trait bound `Utc: Format` is not satisfied
 --> source.rs:4:38
  |
4 | #[cfg_attr(feature = "defmt", derive(defmt::Format))]
  |                                      ^^^^^^^^^^^^^ the trait `Format` is not implemented for `Utc`
  |
 [...]
```

This PR adds the bound. Feel free to interactive-rebase your branch once this is merged to get rid of the fixup commit.